### PR TITLE
Automate daily topic generation

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,41 @@
+name: Daily English Topic
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '5 0 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install python deps
+        run: pip install requests
+      - name: Generate topic markdown
+        env:
+          AZURE_API_KEY: ${{ secrets.AZURE_API_KEY }}
+        run: python scripts/generate_topic.py
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install marp-cli
+        run: npm install -g @marp-team/marp-cli
+      - name: Build HTML
+        run: bash scripts/build_html.sh
+      - name: Commit changes
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "Add daily topic $(date -u +%Y-%m-%d)"
+            git push
+          else
+            echo "No changes to commit"
+          fi

--- a/scripts/build_html.sh
+++ b/scripts/build_html.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+DATE=$(date -u +%m%d%Y)
+mkdir -p "docs/$DATE"
+marp --html --output "docs/$DATE/index.html" "$DATE.md"

--- a/scripts/generate_topic.py
+++ b/scripts/generate_topic.py
@@ -1,0 +1,40 @@
+import os
+import datetime
+import requests
+
+# Endpoint and deployment details
+ENDPOINT = "https://o9274-mau4vl5y-eastus2.cognitiveservices.azure.com"
+DEPLOYMENT = "o4-mini"
+API_VERSION = "2025-01-01-preview"
+
+API_KEY = os.environ.get("AZURE_API_KEY")
+if not API_KEY:
+    raise SystemExit("AZURE_API_KEY env variable is required")
+
+# Read prompt
+with open("prompt.txt", "r", encoding="utf-8") as f:
+    prompt = f.read()
+
+url = f"{ENDPOINT}/openai/deployments/{DEPLOYMENT}/chat/completions?api-version={API_VERSION}"
+
+payload = {
+    "messages": [
+        {"role": "user", "content": prompt}
+    ],
+    "max_tokens": 2000,
+    "model": DEPLOYMENT,
+}
+headers = {
+    "Content-Type": "application/json",
+    "Authorization": f"Bearer {API_KEY}",
+}
+resp = requests.post(url, headers=headers, json=payload)
+resp.raise_for_status()
+content = resp.json()["choices"][0]["message"]["content"]
+
+# Save to markdown file named mmddyyyy.md
+fname = datetime.datetime.utcnow().strftime("%m%d%Y") + ".md"
+with open(fname, "w", encoding="utf-8") as f:
+    f.write(content)
+
+print(f"Wrote {fname}")


### PR DESCRIPTION
## Summary
- add workflow running daily to fetch a topic via Azure OpenAI and build html via Marp
- include helper scripts to call the API and convert markdown

## Testing
- `python -m py_compile scripts/generate_topic.py`
- `bash -n scripts/build_html.sh`

------
https://chatgpt.com/codex/tasks/task_e_684263463cdc83308dba6ef419687414