### PR TITLE
Add index page for topics

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Daily English Topics</title>
+<style>
+body {font-family: Arial, sans-serif; background: linear-gradient(135deg,#eef2f3,#d9e2ec); margin:0;}
+header {background:#0b3d91;color:#fff;padding:1rem;text-align:center;}
+main {max-width:800px;margin:2rem auto;padding:0 1rem;}
+ul {list-style:none;padding:0;}
+li {margin:.5rem 0;}
+a {display:block;padding:.75rem;border-radius:8px;background:#fff;color:#0b3d91;text-decoration:none;font-weight:bold;transition:.2s;}
+a:hover {transform:translateY(-2px);box-shadow:0 4px 6px rgba(0,0,0,0.1);}
+footer {text-align:center;margin:2rem;font-size:.9rem;color:#555;}
+</style>
+</head>
+<body>
+<header><h1>Daily English Topics</h1></header>
+<main>
+  <ul>
+    <li><a href="06082025/index.html">06082025</a></li>
+    <li><a href="06072025/index.html">06072025</a></li>
+    <li><a href="06062025/index.html">06062025</a></li>
+    <li><a href="06022025/index.html">06022025</a></li>
+    <li><a href="05262025/index.html">05262025</a></li>
+  </ul>
+</main>
+<footer>Updated on 2025-06-08</footer>
+</body>
+</html>

--- a/scripts/build_html.sh
+++ b/scripts/build_html.sh
@@ -3,3 +3,4 @@ set -euo pipefail
 DATE=$(date -u +%m%d%Y)
 mkdir -p "docs/$DATE"
 marp --html --output "docs/$DATE/index.html" "$DATE.md"
+python scripts/update_index.py

--- a/scripts/update_index.py
+++ b/scripts/update_index.py
@@ -1,0 +1,50 @@
+import os
+import re
+import datetime
+
+DOCS_DIR = 'docs'
+
+TEMPLATE = """<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+<meta charset=\"UTF-8\">
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+<title>Daily English Topics</title>
+<style>
+body {{font-family: Arial, sans-serif; background: linear-gradient(135deg,#eef2f3,#d9e2ec); margin:0;}}
+header {{background:#0b3d91;color:#fff;padding:1rem;text-align:center;}}
+main {{max-width:800px;margin:2rem auto;padding:0 1rem;}}
+ul {{list-style:none;padding:0;}}
+li {{margin:.5rem 0;}}
+a {{display:block;padding:.75rem;border-radius:8px;background:#fff;color:#0b3d91;text-decoration:none;font-weight:bold;transition:.2s;}}
+a:hover {{transform:translateY(-2px);box-shadow:0 4px 6px rgba(0,0,0,0.1);}}
+footer {{text-align:center;margin:2rem;font-size:.9rem;color:#555;}}
+</style>
+</head>
+<body>
+<header><h1>Daily English Topics</h1></header>
+<main>
+  <ul>
+{items}
+  </ul>
+</main>
+<footer>Updated on {date}</footer>
+</body>
+</html>
+"""
+
+def main():
+    entries = []
+    for name in os.listdir(DOCS_DIR):
+        path = os.path.join(DOCS_DIR, name)
+        if os.path.isdir(path) and re.fullmatch(r'\d{8}', name):
+            entries.append(name)
+    entries.sort(reverse=True)
+    items = "\n".join(f'    <li><a href="{e}/index.html">{e}</a></li>' for e in entries)
+    now = datetime.datetime.utcnow().strftime('%Y-%m-%d')
+    html = TEMPLATE.format(items=items, date=now)
+    with open(os.path.join(DOCS_DIR, 'index.html'), 'w', encoding='utf-8') as f:
+        f.write(html)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- generate a HTML listing of all topic days
- update build script to call the generator
- add the first index page to the site

## Testing
- `python -m py_compile scripts/update_index.py`

------
https://chatgpt.com/codex/tasks/task_e_68454f7d169883309a1dd696954f0bcb