### PR TITLE
Add langchain-based generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Daily English Topic
+
+This project generates daily English learning topics using an Azure OpenAI deployment.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set your Azure OpenAI API key:
+   ```bash
+   export AZURE_API_KEY=your-key
+   ```
+
+## Usage
+
+Run the generator script to create a markdown file for today:
+
+```bash
+python scripts/generate_topic.py
+```
+
+The script retrieves the hottest Reddit post from r/AskReddit (if network access allows) and asks the LLM to produce structured content. The response is returned as JSON with `topic` and `content` fields. The markdown is saved using the pattern `<slug>-DDMMYYYY.md`.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+openai==1.30.5
+langchain==0.1.20
+langchain-community==0.0.38
+langchain-core==0.1.53
+requests>=2.32.4

--- a/scripts/generate_topic.py
+++ b/scripts/generate_topic.py
@@ -1,7 +1,12 @@
 import os
 import datetime
 import re
-from openai import AzureOpenAI
+from typing import Tuple
+
+import requests
+from langchain_community.chat_models import AzureChatOpenAI
+from langchain.prompts import ChatPromptTemplate
+from langchain.output_parsers import StructuredOutputParser, ResponseSchema
 
 # Endpoint and deployment details
 ENDPOINT = "https://o9274-mau4vl5y-eastus2.cognitiveservices.azure.com/"
@@ -16,30 +21,70 @@ if not API_KEY:
 with open("prompt.txt", "r", encoding="utf-8") as f:
     prompt = f.read()
 
-client = AzureOpenAI(
-    api_version=API_VERSION,
-    azure_endpoint=ENDPOINT,
-    api_key=API_KEY,
+def fetch_reddit_post() -> Tuple[str, str]:
+    """Return today's hot Reddit post title and url.
+
+    Falls back to a generic topic if the request fails (e.g. due to network
+    restrictions)."""
+
+    headers = {"User-Agent": "daily-topic-script"}
+    url = "https://www.reddit.com/r/AskReddit/hot.json?limit=1"
+    try:
+        resp = requests.get(url, headers=headers, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()["data"]["children"][0]["data"]
+        title = data.get("title", "Interesting Reddit Discussion")
+        permalink = data.get("permalink", "/")
+        return title, f"https://www.reddit.com{permalink}"
+    except Exception:
+        return "Interesting Reddit Discussion", "https://www.reddit.com/r/AskReddit/"
+
+
+response_schemas = [
+    ResponseSchema(name="topic", description="Title of the topic"),
+    ResponseSchema(name="content", description="Markdown content"),
+]
+parser = StructuredOutputParser.from_response_schemas(response_schemas)
+format_instructions = parser.get_format_instructions()
+
+llm = AzureChatOpenAI(
+    openai_api_version=API_VERSION,
+    openai_api_base=ENDPOINT,
+    openai_api_key=API_KEY,
+    openai_deployment_name=DEPLOYMENT,
 )
 
-response = client.chat.completions.create(
-    messages=[{"role": "user", "content": prompt}],
-    model=DEPLOYMENT,
-    max_completion_tokens=100000,
+reddit_title, reddit_url = fetch_reddit_post()
+
+prompt_tmpl = ChatPromptTemplate.from_messages([
+    ("system", "You are an experienced English learning assistant."),
+    (
+        "system",
+        "Respond in JSON using the following format. {format_instructions}",
+    ),
+    (
+        "user",
+        "{prompt}\n\nUse this Reddit thread as today's discussion topic:\n"
+        "[{{title}}]({{url}})",
+    ),
+])
+
+messages = prompt_tmpl.format_messages(
+    format_instructions=format_instructions,
+    prompt=prompt,
+    title=reddit_title,
+    url=reddit_url,
 )
 
-content = response.choices[0].message.content
+response = llm.invoke(messages)
+parsed = parser.parse(response.content)
+
+content = parsed["content"]
+title_match = parsed.get("topic")
 
 # Determine file name in the form <slug>-DDMMYYYY.md
 today = datetime.datetime.utcnow()
 dmy = today.strftime("%d%m%Y")
-
-title_match = None
-for line in content.splitlines():
-    m = re.search(r"\[([^\]]+)\]\(", line)
-    if m:
-        title_match = m.group(1)
-        break
 
 def slugify(text: str) -> str:
     text = text.strip().lower()


### PR DESCRIPTION
## Summary
- generate a topic using langchain so the model returns JSON
- fetch today's Reddit post with fallback when network access fails
- document setup and usage
- list Python requirements

## Testing
- `python -m py_compile scripts/generate_topic.py`
- `python scripts/generate_topic.py` *(fails: `AZURE_API_KEY env variable is required`)*

------
https://chatgpt.com/codex/tasks/task_e_684e807bc4dc8330b48c7602db3d7582